### PR TITLE
feat: add new variants with icons to the button preview page

### DIFF
--- a/apps/docs/src/pages/button.mdx
+++ b/apps/docs/src/pages/button.mdx
@@ -15,6 +15,11 @@ import Description from "../components/Description.astro";
 <Preview component={Button} name="Primary" />
 <Preview component={Button} name="Primary Small" size="small" />
 <Preview component={Button} name="Primary Outlined" variant="primaryOutlined" />
-<Preview component={Button} name="Primary Outlined Small" variant="primaryOutlined" size="small" />
+<Preview
+  component={Button}
+  name="Primary Outlined Small"
+  variant="primaryOutlined"
+  size="small"
+/>
 <Preview component={Button} name="Link" variant="link" />
 <Preview component={Button} name="Link Small" variant="link" size="small" />

--- a/apps/docs/src/pages/button.mdx
+++ b/apps/docs/src/pages/button.mdx
@@ -5,6 +5,7 @@ layout: ../layouts/MainLayout.astro
 ---
 
 import { Button } from "@selleo/core/src/Button";
+import { PlaceholderIcon } from "@selleo/core/src/icons";
 import Preview from "../components/Preview.astro";
 import Description from "../components/Description.astro";
 
@@ -13,13 +14,130 @@ import Description from "../components/Description.astro";
 </Description>
 
 <Preview component={Button} name="Primary" />
+<Preview
+  component={Button}
+  name="Primary - Icon Start"
+  iconStart={PlaceholderIcon}
+/>
+<Preview
+  component={Button}
+  name="Primary - Icon End"
+  iconEnd={PlaceholderIcon}
+/>
+<Preview
+  component={Button}
+  name="Primary - Icon Start/End"
+  iconStart={PlaceholderIcon}
+  iconEnd={PlaceholderIcon}
+/>
 <Preview component={Button} name="Primary Small" size="small" />
+<Preview
+  component={Button}
+  name="Primary Small - Icon Start"
+  iconStart={PlaceholderIcon}
+  size="small"
+/>
+<Preview
+  component={Button}
+  name="Primary Small - Icon End"
+  iconEnd={PlaceholderIcon}
+  size="small"
+/>
+<Preview
+  component={Button}
+  name="Primary Small - Icon Start/End"
+  iconStart={PlaceholderIcon}
+  iconEnd={PlaceholderIcon}
+  size="small"
+/>
 <Preview component={Button} name="Primary Outlined" variant="primaryOutlined" />
+<Preview
+  component={Button}
+  name="Primary Outlined - Icon Start"
+  variant="primaryOutlined"
+  iconStart={PlaceholderIcon}
+/>
+<Preview
+  component={Button}
+  name="Primary Outlined - Icon End"
+  variant="primaryOutlined"
+  iconEnd={PlaceholderIcon}
+/>
+<Preview
+  component={Button}
+  name="Primary Outlined - Icon Start/End"
+  variant="primaryOutlined"
+  iconStart={PlaceholderIcon}
+  iconEnd={PlaceholderIcon}
+/>
 <Preview
   component={Button}
   name="Primary Outlined Small"
   variant="primaryOutlined"
   size="small"
 />
+<Preview
+  component={Button}
+  name="Primary Outlined Small - Icon Start"
+  variant="primaryOutlined"
+  size="small"
+  iconStart={PlaceholderIcon}
+/>
+<Preview
+  component={Button}
+  name="Primary Outlined Small - Icon End"
+  variant="primaryOutlined"
+  size="small"
+  iconEnd={PlaceholderIcon}
+/>
+<Preview
+  component={Button}
+  name="Primary Outlined Small - Icon Start/End"
+  variant="primaryOutlined"
+  size="small"
+  iconStart={PlaceholderIcon}
+  iconEnd={PlaceholderIcon}
+/>
 <Preview component={Button} name="Link" variant="link" />
+<Preview
+  component={Button}
+  name="Link - Icon Start"
+  variant="link"
+  iconStart={PlaceholderIcon}
+/>
+<Preview
+  component={Button}
+  name="Link - Icon End"
+  variant="link"
+  iconEnd={PlaceholderIcon}
+/>
+<Preview
+  component={Button}
+  name="Link - Icon Start/End"
+  variant="link"
+  iconStart={PlaceholderIcon}
+  iconEnd={PlaceholderIcon}
+/>
 <Preview component={Button} name="Link Small" variant="link" size="small" />
+<Preview
+  component={Button}
+  name="Link Small - Icon Start"
+  variant="link"
+  size="small"
+  iconStart={PlaceholderIcon}
+/>
+<Preview
+  component={Button}
+  name="Link Small - Icon End"
+  variant="link"
+  size="small"
+  iconEnd={PlaceholderIcon}
+/>
+<Preview
+  component={Button}
+  name="Link Small - Icon Start/End"
+  variant="link"
+  size="small"
+  iconStart={PlaceholderIcon}
+  iconEnd={PlaceholderIcon}
+/>

--- a/packages/selleo-design-core/src/Button.tsx
+++ b/packages/selleo-design-core/src/Button.tsx
@@ -4,13 +4,21 @@ import cx from "classnames";
 type Props = {
   variant: "primary" | "primaryOutlined" | "link";
   size: "normal" | "small";
+  iconStart?(props: h.JSX.SVGAttributes<SVGSVGElement>): h.JSX.Element;
+  iconEnd?(props: h.JSX.SVGAttributes<SVGSVGElement>): h.JSX.Element;
+  iconTest?: h.JSX.Element;
 } & Omit<h.JSX.HTMLAttributes<HTMLButtonElement>, "size">;
 
 export function Button({
   variant = "primary",
   size = "normal",
+  iconStart,
+  iconEnd,
+  iconTest,
   ...rest
 }: Props) {
+  const IconStart = iconStart;
+  const IconEnd = iconEnd;
   const buttonClasses = cx(
     "flex transition-colors duration-300 font-bold rounded disabled:opacity-30",
     {
@@ -32,9 +40,16 @@ export function Button({
     "gap-1": size === "normal",
   });
 
+  const iconSize = size === "small" ? 16 : 24;
+
   return (
     <button class={buttonClasses} {...rest}>
-      <div class={contentClasses}>Text</div>
+      <div class={contentClasses}>
+        {IconStart && <IconStart width={iconSize} height={iconSize} />}
+        Text
+        {IconEnd && <IconEnd width={iconSize} height={iconSize} />}
+        {iconTest ? iconTest : ""}
+      </div>
     </button>
   );
 }

--- a/packages/selleo-design-core/src/icons/PlaceholderIcon.tsx
+++ b/packages/selleo-design-core/src/icons/PlaceholderIcon.tsx
@@ -1,0 +1,27 @@
+import { h } from "preact";
+
+export function PlaceholderIcon(props: h.JSX.SVGAttributes<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 25 24"
+      fill="none"
+      {...props}
+    >
+      <path
+        d="M12.5 8V16"
+        stroke="currentColor"
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+      <path
+        d="M16.5 12H8.5"
+        stroke="currentColor"
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+  );
+}

--- a/packages/selleo-design-core/src/icons/index.ts
+++ b/packages/selleo-design-core/src/icons/index.ts
@@ -1,1 +1,2 @@
+export * from "./PlaceholderIcon";
 export * from "./CheckIcon";


### PR DESCRIPTION
This PR includes:
- feat: add new variants with icons to the button preview page
- refactor: expand button component to allow passing start icon and end icon

Closes #48 