### PR TITLE
feat: add select page with examples from figma design system

### DIFF
--- a/apps/docs/src/config.ts
+++ b/apps/docs/src/config.ts
@@ -57,6 +57,7 @@ export const SIDEBAR: Sidebar = {
       { text: "Icon Button", link: "icon-button" },
       { text: "Upload Area", link: "upload-area" },
       { text: "Sidebar", link: "sidebar" },
+      { text: "Select", link: "select" },
     ],
     "More Soon": [{ text: "Text", link: "text" }],
   },

--- a/apps/docs/src/pages/select.mdx
+++ b/apps/docs/src/pages/select.mdx
@@ -1,0 +1,16 @@
+---
+title: Select
+description: Sample Select documentation
+layout: ../layouts/MainLayout.astro
+---
+
+import { Select } from "@selleo/core/src/Select";
+import Preview from "../components/Preview.astro";
+import Description from "../components/Description.astro";
+
+<Description>
+  Below you can find a Select component styled with tailwindcss.
+</Description>
+
+<Preview component={Select} name="Select - Without Label" />
+<Preview component={Select} name="Select - With Label" label="Label" />

--- a/packages/selleo-design-core/src/Select.tsx
+++ b/packages/selleo-design-core/src/Select.tsx
@@ -1,0 +1,41 @@
+import { h } from "preact";
+import { CaretDownIcon } from "./icons/CaretDownIcon";
+
+type Props = {
+  label?: string;
+  placeholder: string;
+} & h.JSX.HTMLAttributes<HTMLSelectElement>;
+
+export function Select({
+  label,
+  placeholder = "Input placeholder",
+  ...props
+}: Props) {
+  return (
+    <div class="inline-block">
+      {label && (
+        <label class="text-neutral-500 dark:text-neutral-400 text-xs mb-1 block">
+          {label}
+        </label>
+      )}
+      <div class="flex justify-between text-neutral-600 dark:text-neutral-300 items-center w-fit text-xs border border-neutral-200 rounded gap-1 relative">
+        <select
+          class="appearance-none outline-none p-2 pr-6 cursor-pointer z-10 bg-transparent"
+          {...props}
+        >
+          <option value="" selected>
+            {placeholder}
+          </option>
+          <option value="option1">Option 1</option>
+          <option value="option2">Option 2</option>
+          <option value="option3">Option 3</option>
+        </select>
+        <CaretDownIcon
+          width={24}
+          height={24}
+          class="m-2 right-0 absolute z-0"
+        />
+      </div>
+    </div>
+  );
+}

--- a/packages/selleo-design-core/src/icons/CaretDownIcon.tsx
+++ b/packages/selleo-design-core/src/icons/CaretDownIcon.tsx
@@ -1,0 +1,27 @@
+import { h } from "preact";
+
+export function CaretDownIcon(props: h.JSX.SVGAttributes<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+      {...props}
+    >
+      <path
+        d="M12 14L15 10.9999"
+        stroke="currentColor"
+        stroke-width="1.2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+      <path
+        d="M9 11L12 14"
+        stroke="currentColor"
+        stroke-width="1.2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+  );
+}


### PR DESCRIPTION
Select component implementation includes only `select` element. For the moment [design](https://www.figma.com/file/aAZNLti1x7RHcKO2aaVdyh/Selleo-Design-System?node-id=2317%3A2064&t=MC6atK6e1XNZEjLS-4) doesn't include any dropdown styles.
 For eventual dropdown styles I would suggest refactor component to include `input` element and `div` for custom dropdown instead of `select`.

Closes #41 