### PR TITLE
feat: add tab components with active and hover state

### DIFF
--- a/apps/docs/src/config.ts
+++ b/apps/docs/src/config.ts
@@ -57,6 +57,7 @@ export const SIDEBAR: Sidebar = {
       { text: "Upload Area", link: "upload-area" },
       { text: "Sidebar", link: "sidebar" },
       { text: "Select", link: "select" },
+      { text: "Tabs", link: "tabs" },
     ],
     "More Soon": [{ text: "Text", link: "text" }],
   },

--- a/apps/docs/src/pages/tabs.mdx
+++ b/apps/docs/src/pages/tabs.mdx
@@ -1,0 +1,25 @@
+---
+title: Tabs
+description: Sample Tabs documentation
+layout: ../layouts/MainLayout.astro
+---
+
+import { Tab } from "@selleo/core/src/Tabs";
+
+import Preview from "../components/Preview.astro";
+import Description from "../components/Description.astro";
+
+<Description>
+  Below you can find a tabs component styled with tailwindcss.
+</Description>
+
+<Preview component={Tab} name="Default tab" active={false} />
+
+<Preview component={Tab} name="Active tab" active={true} />
+
+<Preview
+  component={Tab}
+  name="Tab with icon"
+  active={false}
+  icon={<span>x</span>}
+/>

--- a/apps/docs/src/pages/tabs.mdx
+++ b/apps/docs/src/pages/tabs.mdx
@@ -4,16 +4,19 @@ description: Sample Tabs documentation
 layout: ../layouts/MainLayout.astro
 ---
 
-import { Tab } from "@selleo/core/src/Tabs";
+import { Tab, Tabs } from '@selleo/core/src/Tabs';
+import { DashboardIcon } from '@selleo/core/src/icons';
 
-import Preview from "../components/Preview.astro";
-import Description from "../components/Description.astro";
+import Preview from '../components/Preview.astro';
+import Description from '../components/Description.astro';
 
 <Description>
   Below you can find a tabs component styled with tailwindcss.
 </Description>
 
-<Preview component={Tab} name="Default tab" active={false} />
+<Preview component={Tabs} name="Tabs" tabsAmount={6} selectedId={1} />
+
+<Preview component={Tab} name="Tab" name="Default tab" active={false} />
 
 <Preview component={Tab} name="Active tab" active={true} />
 
@@ -21,5 +24,5 @@ import Description from "../components/Description.astro";
   component={Tab}
   name="Tab with icon"
   active={false}
-  icon={<span>x</span>}
+  icon={DashboardIcon}
 />

--- a/packages/selleo-design-core/src/Tabs.tsx
+++ b/packages/selleo-design-core/src/Tabs.tsx
@@ -1,0 +1,25 @@
+import { h } from "preact";
+import cx from "classnames";
+
+type TabProps = {
+  active: boolean;
+  icon?: JSX.Element;
+};
+
+export function Tab({ active, icon }: TabProps) {
+  const classes = cx(
+    "px-2 py-1 text-base font-normal rounded-lg cursor-pointer",
+    {
+      "text-[#FF6D2A] bg-[#FFF8F5]": active,
+      "text-[#4C4D52] bg-white hover:bg-[#FFF8F5] dark:text-white dark:bg-[#2F3033] dark:hover:bg-[#4C4D52]":
+        !active,
+    }
+  );
+
+  return (
+    <span class={classes}>
+      {icon && "x "}
+      Item
+    </span>
+  );
+}

--- a/packages/selleo-design-core/src/Tabs.tsx
+++ b/packages/selleo-design-core/src/Tabs.tsx
@@ -1,25 +1,45 @@
-import { h } from "preact";
-import cx from "classnames";
+import { h } from 'preact';
+import cx from 'classnames';
 
 type TabProps = {
   active: boolean;
-  icon?: JSX.Element;
+  icon?(): h.JSX.Element;
 };
 
+type TabsProps = {
+  tabsAmount: number;
+  selectedId: number;
+};
+
+export function Tabs({ tabsAmount, selectedId }: TabsProps) {
+  const tabs = Array.from({ length: tabsAmount }, (_, key) => (
+    <Tab active={selectedId === key + 1} />
+  ));
+
+  return <div class="space-x-1">{tabs}</div>;
+}
+
 export function Tab({ active, icon }: TabProps) {
+  const Icon = icon;
+
   const classes = cx(
-    "px-2 py-1 text-base font-normal rounded-lg cursor-pointer",
+    'px-2 py-1 text-base font-normal rounded-lg cursor-pointer',
     {
-      "text-[#FF6D2A] bg-[#FFF8F5]": active,
-      "text-[#4C4D52] bg-white hover:bg-[#FFF8F5] dark:text-white dark:bg-[#2F3033] dark:hover:bg-[#4C4D52]":
+      'text-brand-primary-500 bg-brand-primary-100': active,
+      'text-neutral-600 bg-transparent hover:bg-brand-primary-100 dark:text-white dark:bg-transparent dark:hover:bg-neutral-600':
         !active,
+      'inline-flex items-center': Icon,
     }
   );
 
+  const textClasses = cx({
+    'ml-1': Icon,
+  });
+
   return (
     <span class={classes}>
-      {icon && "x "}
-      Item
+      {Icon && <Icon />}
+      <span class={textClasses}>Item</span>
     </span>
   );
 }


### PR DESCRIPTION
closes #25

- Add Tab component,
- Handled states of a tab:
   - default
   - active
   - hover
   - dark mode