### PR TITLE
fix: input styles

### DIFF
--- a/packages/selleo-design-core/src/Input.tsx
+++ b/packages/selleo-design-core/src/Input.tsx
@@ -32,14 +32,19 @@ export function Input({
     {
       "bg-white border-neutral-200 hover:border-neutral-300":
         !disabled && variant !== "error",
-      "bg-neutral-200 border-neutral-500 hover:border-neutral-500": disabled,
-      "border-danger hover:border-danger": variant === "error",
+      "bg-neutral-200 border-neutral-500 hover:border-neutral-500 cursor-not-allowed":
+        disabled,
+      "bg-white border-danger hover:border-danger": variant === "error",
       "pl-2": !IconStart,
     }
   );
 
-  const iconClasses =
-    "flex items-center peer-valid:text-neutral-600 peer-disabled:text-neutral-500";
+  const iconClasses = cx(
+    "flex items-center peer-valid:text-neutral-600 peer-disabled:text-neutral-500 rounded",
+    {
+      "bg-white": variant === "error",
+    }
+  );
 
   const startIconClasses = cx(iconClasses, "order-first", {
     "pl-1": size === "small",
@@ -52,7 +57,7 @@ export function Input({
   });
 
   const inputClasses = cx(
-    "peer rounded w-full pl-1 outline-0 placeholder:text-neutral-300 group-hover:placeholder:text-neutral-600 focus:placeholder:text-neutral-600 valid:text-neutral-600 disabled:bg-neutral-200 disabled:placeholder:text-neutral-500",
+    "peer rounded w-full pl-1 outline-0 placeholder:text-neutral-300 group-hover:placeholder:text-neutral-600 focus:placeholder:text-neutral-600 valid:text-neutral-600 disabled:bg-neutral-200 disabled:placeholder:text-neutral-500 group-hover:disabled:placeholder:text-neutral-500 disabled:cursor-not-allowed",
     {
       "py-2 text-sm": size === "normal",
       "py-1 text-xs": size === "small",


### PR DESCRIPTION
This PR includes:
- fix: input error state styles for dark theme
Before:
![Zrzut ekranu 2023-03-1 o 13 26 02](https://user-images.githubusercontent.com/71389330/222139037-dbd065fd-5b48-46b0-9071-bd5f5ddb4de8.png)
After:
![Zrzut ekranu 2023-03-1 o 13 28 52](https://user-images.githubusercontent.com/71389330/222139512-245dba5f-9acd-4cfd-b10b-787d6ddecb17.png)

- fix: input disabled state hover text color + fix: add `not-allowed` cursor for disabled state input
Before:

https://user-images.githubusercontent.com/71389330/222140368-d6286699-7b2a-4e4c-a75e-89e55285de46.mov


After:

https://user-images.githubusercontent.com/71389330/222140395-b22703a1-ac11-4b62-aab5-a4cb7ce77011.mov
