### PR TITLE
feat: add ring colors

### DIFF
--- a/packages/selleo-tailwind/tailwind.config.cjs
+++ b/packages/selleo-tailwind/tailwind.config.cjs
@@ -91,6 +91,48 @@ module.exports = {
           },
         },
       },
+      ringColor: {
+        brand: {
+          primary: {
+            100: '#fff8f5',
+            200: '#ffeae0',
+            400: '#ff905d',
+            500: '#ff6d2a', //DEFAULT
+            600: '#e25718',
+          },
+          secondary: {
+            100: '#F3F8FC',
+            200: '#DFEBF6',
+            500: '#5c99d2', //DEFAULT
+            600: '#3871a5',
+          },
+        },
+        white: '#ffffff',
+        black: '#2F3033',
+        danger: '#E81B2F',
+        neutral: {
+          100: '#f4f5f5',
+          200: '#eaeaeb',
+          300: '#bfc0c4',
+          400: '#95979d',
+          500: '#696b72',
+          600: '#4c4d52',
+          hero: {
+            overlay: '#2F3033',
+          },
+        },
+        theme: {
+          dark: '#1f2937',
+          accent: '#3895ff',
+          gray: {
+            100: '#16191d',
+            400: '#586474',
+            800: '#c5cbd3',
+            900: '#e2e5e9',
+            950: '#f0f2f4',
+          },
+        },
+      },
       letterSpacing: {
         none: '0',
         normal: '0.01em',


### PR DESCRIPTION
# Overview

I am trying to implement ring colors to support this:
![image](https://user-images.githubusercontent.com/235847/226057204-c98e2a2e-1b34-49bc-869f-0e36fc755953.png)

Currently no colors are generated for rings so I can't use:
`ring-2 ring-brand-primary-500`


But interesting thing is that locally when I add rings to Avatars it works:

![image](https://user-images.githubusercontent.com/235847/226061734-32a8cab4-dd89-4bf2-902e-2b2e92931b00.png)

Final bundle `designsystem.selleo.com/selleo-ds.css` does not contain ring colors.
Does it happen because tailwind exports only used classes and since rings are not used in components they won't be exported?

[Documentation](https://tailwindcss.com/docs/ring-color#customizing-your-theme) suggests that's you can explicitly add ring colors so I did but I am not sure if that fixes the problem of the final bundle.

