### PR TITLE
Feat/submenu

### DIFF
--- a/apps/docs/src/components/LeftSidebar/LeftSidebar.astro
+++ b/apps/docs/src/components/LeftSidebar/LeftSidebar.astro
@@ -1,6 +1,7 @@
 ---
 import { getLanguageFromURL } from '../../languages';
 import { SIDEBAR } from '../../config';
+import { CaretDownIcon } from '@selleo/core/src/icons';
 
 type Props = {
   currentPage: string;
@@ -25,7 +26,46 @@ const sidebar = SIDEBAR[langCode];
             <h2 class="mb-2 font-bold leading-none text-lg">{header}</h2>
             <ul class="list-none p-0">
               {children.map((child) => {
+                if (child.sublinks) {
+                  return (
+                    <div>
+                      <h2 class="flex leading-none text-md ml-2 font-black mb-1 cursor-pointer w-full subTitle">
+                        {child.subTitle}
+                        <div class="caret-icon z-[-1]">
+                          <CaretDownIcon width={24} height={24} />
+                        </div>
+                      </h2>
+                      <div class="hidden">
+                        {child.sublinks.map((sublink) => {
+                          const sublinkUrl =
+                            Astro.site?.pathname + sublink.link;
+                          return (
+                            <li>
+                              <a
+                                class={`block text-sm m-[1px] py-[0.3rem] px-5 text-inherit hover:no-underline focus:no-underline focus-visible:no-underline hover:bg-theme-gray-950 dark:hover:bg-theme-gray-400 focus-visible:bg-theme-gray-950 dark:focus-visible:bg-theme-gray-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-theme-gray-100 dark:focus-visible:outline-white ${
+                                  currentPageMatch === sublink.link
+                                    ? 'text-theme-accent dark:text-white bg-theme-accent/15 font-semibold'
+                                    : ''
+                                }`}
+                                href={sublinkUrl}
+                                aria-current={
+                                  currentPageMatch === sublink.link
+                                    ? 'page'
+                                    : false
+                                }
+                              >
+                                {sublink.text}
+                              </a>
+                            </li>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  );
+                }
+
                 const url = Astro.site?.pathname + child.link;
+
                 return (
                   <li>
                     <a
@@ -58,5 +98,62 @@ const sidebar = SIDEBAR[langCode];
     if (target && target.offsetTop > window.innerHeight - 100) {
       document.querySelector('.nav-groups').scrollTop = target.offsetTop;
     }
+
+    const subTitles = document.querySelectorAll('.subTitle');
+
+    subTitles.forEach((title) =>
+      title.addEventListener('click', (e) => {
+        e.target.nextElementSibling.classList.toggle('hidden');
+        const iconParent = document.querySelector('.caret-icon');
+
+        iconParent.innerHTML = e.target.nextElementSibling.classList.contains(
+          'hidden'
+        )
+          ? `<svg
+          width="24"
+        height="24"
+            xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="none"
+    >
+      <path
+        d="M12 14L15 10.9999"
+        stroke="white"
+        stroke-width="1.2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+      <path
+        d="M9 11L12 14"
+        stroke="white"
+        stroke-width="1.2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>`
+          : `<svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M12 11L9 14.0001"
+        stroke="white"
+        stroke-width="1.2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+      <path
+        d="M15 14L12 11"
+        stroke="white"
+        stroke-width="1.2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>`;
+      })
+    );
   });
 </script>

--- a/apps/docs/src/components/LeftSidebar/LeftSidebar.astro
+++ b/apps/docs/src/components/LeftSidebar/LeftSidebar.astro
@@ -32,14 +32,14 @@ const sidebar = SIDEBAR[langCode];
 
                 if (child.sublinks) {
                   return (
-                    <div>
-                      <h2 class="flex leading-none text-md ml-2 font-black mb-1 cursor-pointer w-full subTitle">
-                        {child.subTitle}
-                        <div class="caret-icon z-[-1]">
+                    <li>
+                      <div class="subTitle flex items-center cursor-pointer text-sm m-[1px] py-[0.3rem] px-2 text-inherit hover:no-underline focus:no-underline focus-visible:no-underline hover:bg-theme-gray-950 dark:hover:bg-theme-gray-400 focus-visible:bg-theme-gray-950 dark:focus-visible:bg-theme-gray-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-theme-gray-100 dark:focus-visible:outline-white">
+                        <a>{child.text}</a>
+                        <div class="caret-icon z-[1]">
                           <CaretDownIcon width={24} height={24} />
                         </div>
-                      </h2>
-                      <div class={shouldBeExpanded ? '' : 'hidden'}>
+                      </div>
+                      <ul class={`${shouldBeExpanded ? '' : 'hidden'} submenu`}>
                         {child.sublinks.map((sublink) => {
                           const sublinkUrl =
                             Astro.site?.pathname + sublink.link;
@@ -63,8 +63,8 @@ const sidebar = SIDEBAR[langCode];
                             </li>
                           );
                         })}
-                      </div>
-                    </div>
+                      </ul>
+                    </li>
                   );
                 }
 
@@ -105,15 +105,7 @@ const sidebar = SIDEBAR[langCode];
 
     const subTitles = document.querySelectorAll('.subTitle');
 
-    subTitles.forEach((title) =>
-      title.addEventListener('click', (e) => {
-        e.target.nextElementSibling.classList.toggle('hidden');
-        const iconParent = document.querySelector('.caret-icon');
-
-        iconParent.innerHTML = e.target.nextElementSibling.classList.contains(
-          'hidden'
-        )
-          ? `<svg
+    const caretDownIcon = `<svg
           width="24"
         height="24"
             xmlns="http://www.w3.org/2000/svg"
@@ -134,8 +126,9 @@ const sidebar = SIDEBAR[langCode];
         stroke-linecap="round"
         stroke-linejoin="round"
       />
-    </svg>`
-          : `<svg
+    </svg>`;
+
+    const caretUpIcon = `<svg
       width="24"
       height="24"
       viewBox="0 0 24 24"
@@ -157,7 +150,21 @@ const sidebar = SIDEBAR[langCode];
         stroke-linejoin="round"
       />
     </svg>`;
-      })
-    );
+
+    subTitles.forEach((title) => {
+      const submenu = document.querySelector('.submenu');
+
+      title.addEventListener('click', (e) => {
+        submenu.classList.toggle('hidden');
+
+        const iconParent = document.querySelector('.caret-icon');
+
+        iconParent.innerHTML = e.target.nextElementSibling.classList.contains(
+          'hidden'
+        )
+          ? caretDownIcon
+          : caretUpIcon;
+      });
+    });
   });
 </script>

--- a/apps/docs/src/components/LeftSidebar/LeftSidebar.astro
+++ b/apps/docs/src/components/LeftSidebar/LeftSidebar.astro
@@ -26,6 +26,10 @@ const sidebar = SIDEBAR[langCode];
             <h2 class="mb-2 font-bold leading-none text-lg">{header}</h2>
             <ul class="list-none p-0">
               {children.map((child) => {
+                const shouldBeExpanded = child.sublinks?.some(
+                  ({ link }) => link === currentPageMatch
+                );
+
                 if (child.sublinks) {
                   return (
                     <div>
@@ -35,7 +39,7 @@ const sidebar = SIDEBAR[langCode];
                           <CaretDownIcon width={24} height={24} />
                         </div>
                       </h2>
-                      <div class="hidden">
+                      <div class={shouldBeExpanded ? '' : 'hidden'}>
                         {child.sublinks.map((sublink) => {
                           const sublinkUrl =
                             Astro.site?.pathname + sublink.link;

--- a/apps/docs/src/config.ts
+++ b/apps/docs/src/config.ts
@@ -40,7 +40,7 @@ export const ALGOLIA = {
 };
 
 type Link = { text: string; link: string };
-type Submenu = { subTitle: string; sublinks: Link[] };
+type Submenu = { text: string; sublinks: Link[] };
 
 export type Sidebar = Record<
   typeof KNOWN_LANGUAGE_CODES[number],
@@ -56,7 +56,7 @@ export const SIDEBAR: Sidebar = {
     ],
     Components: [
       {
-        subTitle: 'Form',
+        text: 'Form',
         sublinks: [
           { text: 'Input', link: 'input' },
           { text: 'Checkbox', link: 'checkbox' },

--- a/apps/docs/src/config.ts
+++ b/apps/docs/src/config.ts
@@ -39,9 +39,12 @@ export const ALGOLIA = {
   apiKey: 'XXXXXXXXXX',
 };
 
+type Link = { text: string; link: string };
+type Submenu = { subTitle: string; sublinks: Link[] };
+
 export type Sidebar = Record<
   typeof KNOWN_LANGUAGE_CODES[number],
-  Record<string, { text: string; link: string }[]>
+  Record<string, (Link | Submenu)[]>
 >;
 
 export const SIDEBAR: Sidebar = {
@@ -52,16 +55,16 @@ export const SIDEBAR: Sidebar = {
       { text: 'Color', link: 'brand-colors' },
     ],
     Components: [
-      { text: 'Navigation', link: 'navigation' },
-      { text: 'Avatar', link: 'avatars' },
-      { text: 'Button', link: 'button' },
-      { text: 'Checkbox', link: 'checkbox' },
-      { text: 'Input', link: 'input' },
-      { text: 'Select', link: 'select' },
-      { text: 'Sidebar', link: 'sidebar' },
-      { text: 'Tab', link: 'tabs' },
-      { text: 'Testimonial', link: 'testimonials' },
-      { text: 'Text', link: 'text' },
+      {
+        subTitle: 'Form',
+        sublinks: [
+          { text: 'Input', link: 'input' },
+          { text: 'Checkbox', link: 'checkbox' },
+          { text: 'Select', link: 'select' },
+        ],
+      },
+      { text: 'Authentication', link: 'authentication' },
+      { text: 'Dashboard', link: 'dashboard' },
     ],
     'Page Examples': [
       { text: 'Authentication', link: 'authentication' },

--- a/packages/selleo-design-core/src/icons/CaretUpIcon.tsx
+++ b/packages/selleo-design-core/src/icons/CaretUpIcon.tsx
@@ -1,0 +1,29 @@
+import { h } from 'preact';
+
+export function CaretUpIcon(props: h.JSX.SVGAttributes<SVGSVGElement>) {
+  return (
+    <svg
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path
+        d="M12 11L9 14.0001"
+        stroke="#FF6D2A"
+        stroke-width="1.2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+      <path
+        d="M15 14L12 11"
+        stroke="#FF6D2A"
+        stroke-width="1.2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+  );
+}

--- a/packages/selleo-design-core/src/icons/index.ts
+++ b/packages/selleo-design-core/src/icons/index.ts
@@ -24,3 +24,5 @@ export * from './LogoWithPasswordWhite';
 export * from './SelleoSignet';
 export * from './SelleoSignetWhite';
 export * from './MenuIcon';
+export * from './CaretDownIcon';
+export * from './CaretUpIcon';


### PR DESCRIPTION
# Overview:

closes #84 

Short description and worth mentioning decision made.

- Submenu is now possible to use
- The way submenu is implemented:
```js
const SIDEBAR = {
  en: {
    Brand: [
      { text: 'Typography', link: 'brand-typography' },
      { text: 'Logo', link: 'brand-logos' },
      { text: 'Color', link: 'brand-colors' },
    ],
    Components: [
      {
        subTitle: 'Form',
        sublinks: [
          { text: 'Input', link: 'input' },
          { text: 'Checkbox', link: 'checkbox' },
          { text: 'Select', link: 'select' },
        ],
      },
      { text: 'Authentication', link: 'authentication' },
      { text: 'Dashboard', link: 'dashboard' },
    ],
    'Page Examples': [
      { text: 'Authentication', link: 'authentication' },
      { text: 'Dashboard', link: 'dashboard' },
    ],
  },
};
```

# Preview

## Not expanded submenu
![image](https://user-images.githubusercontent.com/77807844/226642645-92da7f01-8225-4c3f-b2b7-d434839c5820.png)

## Expanded submenu
![image](https://user-images.githubusercontent.com/77807844/226642809-783e3359-20bc-496c-b5ae-d0b20f0a5de9.png)

